### PR TITLE
Backfill missing lab metadata (3 files)

### DIFF
--- a/Instructions/Labs/01a-m365-copilot.md
+++ b/Instructions/Labs/01a-m365-copilot.md
@@ -1,7 +1,7 @@
 ---
 lab:
   title: Explore Microsoft 365 Copilot
-  description: 'In this exercise, you''ll harness the power of Copilot to explore a new business idea: starting a corporate cleaning company.'
+  description: 'In this exercise, you'll harness the power of Copilot to explore a new business idea: starting a corporate cleaning company.'
   duration: 40 minutes
   level: 100
   islab: true

--- a/Instructions/Labs/01a-m365-copilot.md
+++ b/Instructions/Labs/01a-m365-copilot.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Explore Microsoft 365 Copilot'
+  title: Explore Microsoft 365 Copilot
+  description: 'In this exercise, you''ll harness the power of Copilot to explore a new business idea: starting a corporate cleaning company.'
+  duration: 40 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Microsoft 365
+    - Microsoft 365 Copilot
 ---
+
 # Explore Microsoft 365 Copilot
 
 Welcome to the exciting world of Microsoft 365 Copilot!

--- a/Instructions/Labs/01b-ms-copilot.md
+++ b/Instructions/Labs/01b-ms-copilot.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Explore Copilot in Microsoft Edge'
+  title: Explore Copilot in Microsoft Edge
+  description: 'In this exercise, you''ll harness the power of Copilot to explore a new business idea: starting a corporate cleaning company.'
+  duration: 40 minutes
+  level: 100
+  islab: true
 ---
+
 # Explore Microsoft Copilot in Microsoft Edge
 
 Welcome to the exciting world of Microsoft Copilot!

--- a/Instructions/Labs/01b-ms-copilot.md
+++ b/Instructions/Labs/01b-ms-copilot.md
@@ -1,7 +1,7 @@
 ---
 lab:
   title: Explore Copilot in Microsoft Edge
-  description: 'In this exercise, you''ll harness the power of Copilot to explore a new business idea: starting a corporate cleaning company.'
+  description: 'In this exercise, you'll harness the power of Copilot to explore a new business idea: starting a corporate cleaning company.'
   duration: 40 minutes
   level: 100
   islab: true

--- a/Instructions/Labs/01c-m365-web-copilot.md
+++ b/Instructions/Labs/01c-m365-web-copilot.md
@@ -1,7 +1,7 @@
 ---
 lab:
   title: Explore Microsoft 365 Copilot (Web version)
-  description: 'In this exercise, you''ll harness the power of Copilot to explore a new business idea: starting a corporate cleaning company using the web versions of Microsoft 365 applications.'
+  description: 'In this exercise, you'll harness the power of Copilot to explore a new business idea: starting a corporate cleaning company using the web versions of Microsoft 365 applications.'
   duration: 40 minutes
   level: 100
   islab: true

--- a/Instructions/Labs/01c-m365-web-copilot.md
+++ b/Instructions/Labs/01c-m365-web-copilot.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Explore Microsoft 365 Copilot (Web version)'
+  title: Explore Microsoft 365 Copilot (Web version)
+  description: 'In this exercise, you''ll harness the power of Copilot to explore a new business idea: starting a corporate cleaning company using the web versions of Microsoft 365 applications.'
+  duration: 40 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Microsoft 365
+    - Microsoft 365 Copilot
 ---
+
 # Explore Microsoft 365 Copilot (Web Version)
 
 Welcome to the exciting world of Microsoft 365 Copilot using the web-based Microsoft 365 applications!


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 3

- `Instructions/Labs/01a-m365-copilot.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/01b-ms-copilot.md` (description,duration,level,islab)
- `Instructions/Labs/01c-m365-web-copilot.md` (description,duration,level,islab,primarytopics)
